### PR TITLE
Use canonical YAML truthy values

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,9 +1,9 @@
 [defaults]
-host_key_checking = False
+host_key_checking = false
 timeout = 60
 
 [inventory]
 enable_plugins = aws_ec2
 
 [ssh_connection]
-pipelining = True
+pipelining = true

--- a/database.yml
+++ b/database.yml
@@ -12,7 +12,7 @@
 - hosts: aws_ec2
   serial: 1
   remote_user: centos
-  become: yes
+  become: true
   roles:
     - role: informix-db
       vars:

--- a/devices.yml
+++ b/devices.yml
@@ -12,7 +12,7 @@
 - hosts: aws_ec2
   serial: 1
   remote_user: centos
-  become: yes
+  become: true
   roles:
     - role: iscsi-devices
       vars:

--- a/management.yml
+++ b/management.yml
@@ -12,9 +12,9 @@
 - hosts: aws_ec2
   serial: 1
   remote_user: centos
-  become: yes
+  become: true
   roles:
     - role: informix-management
       vars:
-        informix_management_alerts_enabled: yes
+        informix_management_alerts_enabled: true
         informix_management_alerts_vault_path: "{{ vault_base_path }}/alerts"

--- a/nfs.yml
+++ b/nfs.yml
@@ -12,6 +12,6 @@
 - hosts: aws_ec2
   serial: 1
   remote_user: centos
-  become: yes
+  become: true
   roles:
     - role: nfs-mounts


### PR DESCRIPTION
These changes ensure that truthy values are represented using canonical [YAML boolean form](https://yaml.org/spec/1.2.1/#id2803629) in accordance with recent [Ansible documentation updates](https://github.com/ansible/ansible/pull/78429) and will suppress `yamllint` warnings.