### PR TITLE
Use companieshouse.middleware collection roles

### DIFF
--- a/database.yml
+++ b/database.yml
@@ -14,7 +14,7 @@
   remote_user: centos
   become: true
   roles:
-    - role: informix-db
+    - role: companieshouse.middleware.informix_db
       vars:
         informix_db_server_name_suffix: "{{ informix_server_name_suffix }}"
         informix_db_vault_path: "{{ vault_base_path }}/informix"

--- a/devices.yml
+++ b/devices.yml
@@ -14,6 +14,6 @@
   remote_user: centos
   become: true
   roles:
-    - role: iscsi-devices
+    - role: companieshouse.middleware.iscsi_devices
       vars:
         iscsi_devices_vault_path: "{{ vault_base_path }}/iscsi"

--- a/management.yml
+++ b/management.yml
@@ -14,7 +14,7 @@
   remote_user: centos
   become: true
   roles:
-    - role: informix-management
+    - role: companieshouse.middleware.informix_management
       vars:
         informix_management_alerts_enabled: true
         informix_management_alerts_vault_path: "{{ vault_base_path }}/alerts"

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,16 +1,5 @@
 ---
 
-roles:
-  - src: https://github.com/companieshouse/ansible-role-informix-db
-    name: informix-db
-    version: "1.0.6"
-  - src: https://github.com/companieshouse/ansible-role-informix-management
-    name: informix-management
-    version: "1.0.6"
-  - src: https://github.com/companieshouse/ansible-role-iscsi-devices
-    name: iscsi-devices
-    version: "1.1.3"
-
 collections:
   - name: amazon.aws
     version: "8.1.0"
@@ -18,3 +7,5 @@ collections:
     version: "9.3.0"
   - name: companieshouse.general
     version: "1.2.2"
+  - name: companieshouse.middleware
+    version: "1.1.0"


### PR DESCRIPTION
This change replaces several standalone roles with roles from the [ansible-collection-middleware](https://github.com/companieshouse/ansible-collection-middleware) collection for simplified management.