### PR TITLE
Define AIS image directory path to ensure correct ownership

### DIFF
--- a/roles/deploy/defaults/main.yml
+++ b/roles/deploy/defaults/main.yml
@@ -16,6 +16,8 @@ cloudwatch_agent_defaults:
 
 data_directories:
   ais:
+    - path: /image/ais
+      type: dir
     - path: /export/home
       type: dir
     - path: /export/home/ais


### PR DESCRIPTION
The `/image/ais` directory is created with default `root:root` ownership in a separate role when mounting external NFS shares. This change ensures that the directory is applied `ais:ais` ownership to avoid service access issues.