### PR TITLE
Add log rotation configuration for AIS services

### DIFF
--- a/roles/deploy/defaults/main.yml
+++ b/roles/deploy/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 
+ais_log_rotation_config_path: /etc/logrotate.ais.conf
 ais_logs_path: /ais/logs
 ais_profile_path: /ais/ais.profile
 

--- a/roles/deploy/tasks/cron.yml
+++ b/roles/deploy/tasks/cron.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: Create system cron job for log rotation
+- name: Create system cron job for Tuxedo log rotation
   ansible.builtin.cron:
     name: Log rotation for Tuxedo services
     weekday: "*"
@@ -8,6 +8,16 @@
     hour: "*"
     user: "root"
     job: "/sbin/logrotate {{ tuxedo_log_rotation_config_path }}"
+    cron_file: /etc/cron.d/log-rotation
+
+- name: Create system cron job for AIS log rotation
+  ansible.builtin.cron:
+    name: Log rotation for AIS services
+    weekday: "*"
+    minute: "0"
+    hour: "7"
+    user: "root"
+    job: "/sbin/logrotate {{ ais_log_rotation_config_path }}"
     cron_file: /etc/cron.d/log-rotation
 
 - name: Create maintenance job for periodic mail spool truncation

--- a/roles/deploy/tasks/main.yml
+++ b/roles/deploy/tasks/main.yml
@@ -95,13 +95,18 @@
     mode: '0755'
     state: directory
 
-- name: Create shared log rotation configuration for Tuxedo services
+- name: Create shared log rotation configuration for Tuxedo and AIS services
   ansible.builtin.template:
-    src: templates/logrotate.tuxedo.conf.j2
-    dest: "{{ tuxedo_log_rotation_config_path }}"
+    src: "{{ item.src }}"
+    dest: "{{ item.dest }}"
     owner: root
     group: root
     mode: '0644'
+  loop:
+    - src: templates/logrotate.tuxedo.conf.j2
+      dest: "{{ tuxedo_log_rotation_config_path }}"
+    - src: templates/logrotate.ais.conf.j2
+      dest: "{{ ais_log_rotation_config_path }}"
 
 - name: Configure cron jobs
   ansible.builtin.import_tasks: cron.yml

--- a/roles/deploy/templates/logrotate.ais.conf.j2
+++ b/roles/deploy/templates/logrotate.ais.conf.j2
@@ -1,0 +1,27 @@
+{{ ais_logs_path }}/audlog
+{{ ais_logs_path }}/audlog.report
+{{ ais_logs_path }}/debug/*import_output
+{{ ais_logs_path }}/debug/BSSlog
+{{ ais_logs_path }}/errlog
+{{ ais_logs_path }}/ExportLog.*
+{{ ais_logs_path }}/output_debug_*
+{{ ais_logs_path }}/route400/*.log
+{{ ais_logs_path }}/syslog
+{{ ais_logs_path }}/testing/doc_retrieval
+{{ ais_logs_path }}/testing/file_ret_client
+{{ ais_logs_path }}/testing/notify
+{{ ais_logs_path }}/trace_debug_message
+{
+  daily
+  copytruncate
+  compress
+  notifempty
+  olddir {{ ais_logs_path }}/archive
+  createolddir 0755 root root
+  rotate 31
+
+  lastaction
+    /bin/find {{ ais_logs_path }}/archive -name '*import_output' -mtime +31 -exec rm -f {} \;
+    /bin/find {{ ais_logs_path }}/debug -maxdepth 1 -name '*import_output' -size 0 -delete
+  endscript
+}

--- a/roles/deploy/templates/logrotate.ais.conf.j2
+++ b/roles/deploy/templates/logrotate.ais.conf.j2
@@ -21,7 +21,7 @@
   rotate 31
 
   lastaction
-    /bin/find {{ ais_logs_path }}/archive -name '*import_output' -mtime +31 -exec rm -f {} \;
+    /bin/find {{ ais_logs_path }}/archive -name '*import_output*.gz' -mtime +31 -exec rm -f {} \;
     /bin/find {{ ais_logs_path }}/debug -maxdepth 1 -name '*import_output' -size 0 -delete
   endscript
 }

--- a/roles/deploy/templates/logrotate.tuxedo.conf.j2
+++ b/roles/deploy/templates/logrotate.tuxedo.conf.j2
@@ -26,26 +26,3 @@
     /bin/find {{ tuxedo_logs_path }} -maxdepth 2 -name 'ULOG.*' -not -name "ULOG.$(date +%m%d%y)" -size 0 -delete
   endscript
 }
-
-{{ ais_logs_path }}/audlog
-{{ ais_logs_path }}/audlog.report
-{{ ais_logs_path }}/debug/*import_output
-{{ ais_logs_path }}/debug/BSSlog
-{{ ais_logs_path }}/errlog
-{{ ais_logs_path }}/ExportLog.*
-{{ ais_logs_path }}/output_debug_*
-{{ ais_logs_path }}/route400/*.log
-{{ ais_logs_path }}/syslog
-{{ ais_logs_path }}/testing/doc_retrieval
-{{ ais_logs_path }}/testing/file_ret_client
-{{ ais_logs_path }}/testing/notify
-{{ ais_logs_path }}/trace_debug_message
-{
-  daily
-  copytruncate
-  compress
-  notifempty
-  olddir /ais/logs/archive
-  createolddir 0755 root root
-  rotate 365
-}


### PR DESCRIPTION
Currently, on-premise AIS logs are archived as part of a daily cron job that first stops the syslog daemon—forcing it to relinquish its open file descriptors—before moving the log files to an archive directory, creating empty log files, and finally restarting the syslog daemon (hence avoiding issues due to the change in inodes). Log messages may be lost for the duration that the syslog daemon is stopped. This process has been replaced with `logrotate` configuration which _truncates_ the log file and therefore does not require the syslog daemon to be stopped, and open file descriptors are unaffected.

An edge case has been identified where this truncation may impact cron jobs that read particular log files (e.g. `BSSlog`) should they be truncated while certain processes are running (e.g. the long-running import process). This change ensures that log rotation will only be considered at a defined period in the day where such processes are not running.