### PR TITLE
Add URA key for AIS services

### DIFF
--- a/roles/deploy/defaults/main.yml
+++ b/roles/deploy/defaults/main.yml
@@ -115,3 +115,5 @@ tuxedo_log_files:
       cloudwatch_log_group_name: ais-tuxedo-ais-syslog
     - file_pattern: "{{ tuxedo_logs_path }}/ULOG*"
       cloudwatch_log_group_name: ais-tuxedo-ais-ulog
+
+ura_key_vault_path: "{{ vault_base_path }}/ura"

--- a/roles/deploy/tasks/main.yml
+++ b/roles/deploy/tasks/main.yml
@@ -23,6 +23,24 @@
       - application_configs_path is defined and application_configs_path | trim | length > 0
     msg: "Required variable(s) empty or undefined"
 
+- name: Retrieve URA key from Hashicorp Vault
+  ansible.builtin.set_fact:
+    ura_config: "{{ lookup('community.hashi_vault.hashi_vault', ura_key_vault_path) }}"
+
+- name: Check URA key is present
+  ansible.builtin.assert:
+    that:
+      - ura_config.key is defined and ura_config.key | trim | length > 0
+    msg: "URA key Vault variable is empty or undefined"
+
+- name: Create URA key file
+  ansible.builtin.template:
+    src: templates/uraki.j2
+    dest: /etc/uraki
+    owner: root
+    group: root
+    mode: '0644'
+
 # The hostname is assumed to be in the format: ais-tuxedo-<environment>-<instance-index>
 - name: Set common Tuxedo fact for domain suffix
   ansible.builtin.set_fact:

--- a/roles/deploy/templates/uraki.j2
+++ b/roles/deploy/templates/uraki.j2
@@ -1,0 +1,1 @@
+{{ ura_config.key }}


### PR DESCRIPTION
This change ensures that the URA key is present for decryption of TIFF images during the AIS import process and resolves issues with the `doc_retrieval` process.