### PR TITLE
feat: Add ServiceTeam: CSI tag to AIS instances

### DIFF
--- a/groups/ais/instance.tf
+++ b/groups/ais/instance.tf
@@ -126,6 +126,7 @@ resource "aws_instance" "ais" {
 
   tags = merge(local.common_tags, {
     Name = "${var.service_subtype}-${var.service}-${var.environment}-${count.index + 1}"
+    ServiceTeam = "CSI"
   })
   volume_tags = local.common_tags
 }


### PR DESCRIPTION
Adds ServiceTeam: CSI tag to AIS instances as part of CSI infrastructure tagging work.